### PR TITLE
Suggest to use specific epithet instead of (binomial) species name ma…

### DIFF
--- a/globi.json
+++ b/globi.json
@@ -54,7 +54,7 @@
         "titles" : "pollinator_genus",
         "datatype" : "string"
       }, {
-        "name" : "sourceTaxonSpeciesName",
+        "name" : "sourceTaxonSpecificEpithetName",
         "titles" : "pollinator_species",
         "datatype" : "string"
       }, {
@@ -66,7 +66,7 @@
         "titles" : "plant_genus",
         "datatype" : "string"
       }, {
-        "name" : "targetTaxonSpeciesName",
+        "name" : "targetTaxonSpecificEpithetName",
         "titles" : "plant_species",
         "datatype" : "string"
       } ]


### PR DESCRIPTION
…pping

@zedomel Thanks for making this mapping. I've been using mapping to sourceTaxonSpeciesName for columns that include names like "Homo sapiens" and sourceTaxonSpecificEpithetName for columns that report genus and epithet into separately. Would it help to include some kind of schema / docs as part of the generated files when running "elton init ..." ? Or, perhaps you have other ideas to make it easier to define / discuss supported mappings. 